### PR TITLE
Basic grid view option not showing if resource is not tabular

### DIFF
--- a/ckanext/iaea/templates/package/resource_views.html
+++ b/ckanext/iaea/templates/package/resource_views.html
@@ -1,0 +1,24 @@
+{% ckan_extends %}
+{{ super() }}
+{% block page_primary_action %}
+<div class="dropdown btn-group">
+    <a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" href="#">
+      <i class="fa fa-plus-square"></i>
+      {{ _('New view') }}
+      <span class="caret"></span>
+    </a>
+
+    <ul class="dropdown-menu">
+      {% for option in h.get_allowed_view_types(c.resource, c.pkg_dict)  %}
+        {% if (c.resource['Media type'].startswith('image') or c.resource['Media type'].startswith('application/geo')) and option[0]=='basicgrid' %}
+            <!-- continue -->
+        {% else %}
+            {% set url = h.url_for(controller='package', action='edit_view', id=c.pkg_dict.name, resource_id=c.resource.id, view_type=option[0]) %}
+            <li><a href="{{ url }}"><i class="fa fa-{{ option[2] }}"></i> {{ option[1] }}</a></li>
+        {% endif %}
+      {% endfor %}
+    </ul>
+  </div>
+  {% resource 'vendor/reorder' %}
+   
+{% endblock %}


### PR DESCRIPTION
In the template on New View button on the resource, the Basic grid option is passed if data is image or geojson. 