### PR TITLE
Adds custom IAEA metadata schema for dataset.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ To build the images:
 docker compose build
 ```
 
+
+## Configuration
+
+You should set CKAN auth option to allow for datasets without organization:
+```
+ckan.auth.create_unowned_dataset = true
+```
+
+### Optional
+
+```
+# Main organization name for the portal. Default value is 'iaea'
+ckanext.iaea.main_organization=iaea
+```
+
 ## Run the full portal
 To start the containers:
 

--- a/ckan/development.ini
+++ b/ckan/development.ini
@@ -63,7 +63,7 @@ ckan.site_url = http://ckan.iaea.local:5000
 ## Authorization Settings
 
 ckan.auth.anon_create_dataset = false
-ckan.auth.create_unowned_dataset = false
+ckan.auth.create_unowned_dataset = true
 ckan.auth.create_dataset_if_not_in_organization = false
 ckan.auth.user_create_groups = false
 ckan.auth.user_create_organizations = false
@@ -104,7 +104,7 @@ ckan.redis.url = redis://localhost:6379/0
 #ckan.plugins = envvars image_view text_view recline_view webpage_view pdf_view pages datastore datapusher harvest ckan_harvester iaea iaea_db_harvester authz_service
 #ckan.plugins = image_view text_view recline_view
 #ckan.plugins = envvars stats text_view recline_view image_view webpage_view resource_proxy datastore datapusher report archiver qa harvest ckan_harvester authz_service sentry linechart barchart piechart basicgrid visualize pdf_view geo_view geojson_view wmts_view shp_view pages dataexplorer_view dataexplorer_table_view dataexplorer_chart_view dataexplorer_map_view dcat dcat_rdf_harvester dcat_json_harvester dcat_json_interface structured_data iaea
-ckan.plugins = envvars stats text_view image_view webpage_view resource_proxy datastore datapusher iaea validation qa report archiver harvest ckan_harvester authz_service sentry linechart barchart piechart basicgrid visualize pdf_view geo_view geojson_view wmts_view shp_view pages dataexplorer_view dataexplorer_table_view dataexplorer_chart_view dataexplorer_map_view dcat dcat_rdf_harvester dcat_json_harvester dcat_json_interface structured_data scheming_datasets scheming_groups scheming_organizations
+ckan.plugins = envvars stats text_view image_view webpage_view resource_proxy datastore datapusher visualize iaea validation qa report archiver harvest ckan_harvester authz_service sentry linechart barchart piechart basicgrid pdf_view geo_view geojson_view wmts_view shp_view pages dataexplorer_view dataexplorer_table_view dataexplorer_chart_view dataexplorer_map_view dcat dcat_rdf_harvester dcat_json_harvester dcat_json_interface structured_data scheming_datasets scheming_groups scheming_organizations saml2auth
 
 # Define which views should be created by default
 # (plugins must be loaded in ckan.plugins)
@@ -210,6 +210,58 @@ ckanext.authz_service.jwt_algorithm=RS256
 
 # Googleanalytics
 ckanext.iaea.googleanalytics.id=G-REPLACEME
+
+ckanext.iaea.main_organization=orgone
+
+## ckanext-saml2auth
+# Specifies the metadata location type
+# Options: local or remote
+ckanext.saml2auth.idp_metadata.location = local
+
+# Path to a local file accessible on the server the service runs on
+# Ignore this config if the idp metadata location is set to: remote
+ckanext.saml2auth.idp_metadata.local_path = /home/pavle/projects/keitaro/ckanext-iaea/sso_idp.xml
+
+# A remote URL serving aggregate metadata
+# Ignore this config if the idp metadata location is set to: local
+# ckanext.saml2auth.idp_metadata.remote_url = https://kalmar2.org/simplesaml/module.php/aggregator/?id=kalmarcentral2&set=saml2
+
+# Path to a local file accessible on the server the service runs on
+# Ignore this config if the idp metadata location is set to: local and metadata is public
+# ckanext.saml2auth.idp_metadata.remote_cert = /opt/metadata/kalmar2.cert
+
+# Corresponding SAML user field for firstname
+ckanext.saml2auth.user_firstname = FirstName
+
+# Corresponding SAML user field for lastname
+ckanext.saml2auth.user_lastname = LastName
+
+# Corresponding SAML user field for fullname
+# (Optional: Can be used as an alternative to firstname + lastname)
+# ckanext.saml2auth.user_fullname = fullname
+
+# Corresponding SAML user field for email
+ckanext.saml2auth.user_email = EmailAddress
+
+# URL route of the endpoint where the SAML assertion is sent, also known as Assertion Consumer Service (ACS).
+# Default: /acs
+ckanext.saml2auth.acs_endpoint = /sso/post
+
+# Configuration setting that enables CKAN's internal register/login functionality as well
+# Default: False
+ckanext.saml2auth.enable_ckan_internal_login = True
+
+# Entity ID (also know as Issuer)
+# Define the entity ID. Default is urn:mace:umu.se:saml:ckan:sp
+# ckanext.saml2auth.entity_id = WebSSO-saml2-new
+ckanext.saml2auth.entity_id=https://data-staging.iaea.org
+
+
+## CKAN Scheming
+scheming.dataset_schemas = ckanext.iaea:iaea_dataset_schema.yaml
+scheming.presets = ckanext.scheming:presets.json ckanext.iaea:presets.json
+
+
 
 ## Logging configuration
 [loggers]

--- a/ckanext/iaea/helpers.py
+++ b/ckanext/iaea/helpers.py
@@ -1,6 +1,7 @@
 import logging
 
 import ckan.plugins.toolkit as tk
+import ckan.lib.helpers as h
 
 
 CONFIG_GA_ID='ckanext.iaea.googleanalytics.id'
@@ -29,7 +30,50 @@ def googleanalytics_header():
     )
 
 
+def get_available_organizations(data_dict):
+    '''Returns a list of available organizations for the UI Create and Update dataset.
+    The organizations are restricted to:
+     - No organization
+     - The main configured organization (default 'iaea')
+     - Any organization that the package currently has, for compatibility
+       with datasets that are already created on different organizations.
+    '''
+    available = h.organizations_available('create_dataset')
+    organizations = []
+
+    curr_org = data_dict.get('organization')
+    main_org = get_main_organization()
+
+    if not available:
+        available = []
+
+    for org in available:
+        if main_org and org.get('name').lower() == main_org.get('name').lower():
+            organizations.append(org)
+        elif curr_org and curr_org.get('name').lower() == org.get('name').lower():
+            organizations.append(org)
+
+    return organizations
+
+
+def get_main_organization():
+    '''Returns the main organization for the portal.
+    The is read from configuration property: ckanext.iaea.main_organization
+    Returns the Organization data dict or None if there is no such organization.
+    '''
+    org_name = tk.config.get('ckanext.iaea.main_organization', 'iaea')
+    try:
+        return tk.get_action('organization_show')({
+            'ignore_auth': True,
+        }, {
+            'id': org_name,
+        })
+    except tk.ObjectNotFound:
+        return None
+
+
 def get_helpers():
     return {
         "iaea_ga_header": googleanalytics_header,
+        'iaea_get_available_organizations': get_available_organizations,
     }

--- a/ckanext/iaea/iaea_dataset_schema.yaml
+++ b/ckanext/iaea/iaea_dataset_schema.yaml
@@ -1,0 +1,111 @@
+scheming_version: 2
+dataset_type: dataset
+about: A reimplementation of the default CKAN dataset schema
+about_url: http://github.com/ckan/ckanext-scheming
+
+
+dataset_fields:
+
+- field_name: title
+  label: Title
+  preset: title
+  form_placeholder: eg. A descriptive title
+
+- field_name: name
+  label: URL
+  preset: dataset_slug
+  form_placeholder: eg. my-dataset
+
+- field_name: notes
+  label: Description
+  form_snippet: markdown.html
+  form_placeholder: eg. Some useful notes about the data
+
+- field_name: tag_string
+  label: Tags
+  preset: tag_string_autocomplete
+  form_placeholder: eg. economy, mental health, government
+
+- field_name: license_id
+  label: License
+  form_snippet: license.html
+  help_text: License definitions and additional information can be found at http://opendefinition.org/
+
+- field_name: owner_org
+  label: Organization
+  preset: iaea_dataset_organization
+
+- field_name: url
+  label: Source
+  form_placeholder: http://example.com/dataset.json
+  display_property: foaf:homepage
+  display_snippet: link.html
+
+- field_name: version
+  label: Version
+  validators: ignore_missing unicode_safe package_version_validator
+  form_placeholder: '1.0'
+
+- field_name: author
+  label: Author(s)
+  form_placeholder: Joe Bloggs
+  display_property: dc:creator
+
+
+- field_name: maintainer
+  label: Maintainer
+  form_placeholder: Joe Bloggs
+  display_property: dc:contributor
+
+- field_name: maintainer_email
+  label: Maintainer Email
+  form_placeholder: joe@example.com
+  display_property: dc:contributor
+  display_snippet: email.html
+  display_email_name_field: maintainer
+
+- field_name: update_frequency
+  label: Update Frequency
+  preset: select
+  form_placeholder: "Select update frequency like: weekly or monthly"
+  choices:
+  - value: daily
+    label: Daily
+  - value: weekly
+    label: Weekly
+  - value: monthly
+    label: Monthly
+  - value: yearly
+    label: Yearly
+  - value: ad-hoc
+    label: Ad-hoc
+  - value: never
+    label: Never
+
+- field_name: preferred_form_of_citation
+  label: Preferred Form of Citation
+  form_placeholder: "eg. INTERNATIONAL ATOMIC ENERGY AGENCY, [TITLE]. IN: IAEA Data Platform [online], IAEA, Vienna [YEAR]."
+
+- field_name: featured_view
+  preset: not_displayed
+  display_snippet: null
+  validators: ignore_empty
+
+resource_fields:
+
+- field_name: url
+  label: URL
+  preset: resource_url_upload
+
+- field_name: name
+  label: Name
+  form_placeholder: eg. January 2011 Gold Prices
+
+- field_name: description
+  label: Description
+  form_snippet: markdown.html
+  form_placeholder: Some useful notes about the data
+
+- field_name: format
+  label: Format
+  preset: resource_format_autocomplete

--- a/ckanext/iaea/logic/action.py
+++ b/ckanext/iaea/logic/action.py
@@ -2,8 +2,9 @@ import logging
 import ckan.lib.datapreview as datapreview
 import ckan.logic as l
 import ckan.plugins as p
-
 from ckan.logic.schema import default_create_resource_view_schema, default_update_resource_view_schema
+
+from ckanext.iaea.helpers import get_main_organization
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/iaea/logic/validators.py
+++ b/ckanext/iaea/logic/validators.py
@@ -1,0 +1,52 @@
+import ckan.plugins.toolkit as tk
+import ckan.lib.helpers as h
+import ckan.lib.navl.dictization_functions as df
+from ckan.common import _
+
+from ckanext.iaea.helpers import get_main_organization
+
+
+def package_organization_validator(value, context):
+    '''Validates the organization on create/update package.
+    The organization must be one of:
+     - Empty value i.e. no owner organization for the package.
+     - If set, then it must be set to the main organization of the portal.
+     - If the package already was owned by an organization, the value must either be that old
+       organization or the main portal organization (this is for compatibility with older packages).
+    '''
+    if not value:
+        return value
+    
+    main_org = get_main_organization()
+    package = context.get('package')
+
+    if not package and not main_org:
+        raise df.Invalid(_('Only datasets without organization are allowed'))
+
+    if not package:
+        # Check that the current owner_org is the main owner_org
+        if value.lower() != main_org.get('name').lower() and value.lower() != main_org.get('id').lower():
+            raise df.Invalid(_('The dataset owner organization must be {} or empty').format(main_org.get('name')))
+
+    if package and main_org:
+        new_org = _get_organization(value)
+        if not new_org:
+            raise df.Invalid(_('Package owner organization does not exist'))
+        if new_org.get('id') != package.owner_org:
+            # The owner organization was updated, so it must be set to the main organization or not at all.
+            if new_org.get('id') != main_org.get('id'):
+                # The new owner org is not the main org.
+                raise df.Invalid(_('You can only update the package owner organization to {} or leave the old one.').format(main_org.get('name')))
+
+    return value
+
+
+def _get_organization(value):
+    try:
+        return tk.get_action('organization_show')({
+            'ignore_auth': True,
+        }, {
+            'id': value,
+        })
+    except tk.ObjectNotFound:
+        return None

--- a/ckanext/iaea/plugin.py
+++ b/ckanext/iaea/plugin.py
@@ -2,7 +2,7 @@ import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 import ckan.logic as logic
 from ckan.lib.plugins import DefaultTranslation
-from ckanext.iaea.logic import action
+from ckanext.iaea.logic import action, validators
 from flask import Blueprint
 from ckanext.iaea import view
 import ckan.model as model
@@ -72,6 +72,7 @@ class IaeaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm,
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IDatasetForm)
     plugins.implements(plugins.IActions)
+    plugins.implements(plugins.IValidators)
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.ITemplateHelpers, inherit=True)
 
@@ -119,8 +120,15 @@ class IaeaPlugin(plugins.SingletonPlugin, toolkit.DefaultDatasetForm,
     def get_actions(self):
         return {
             'resource_view_create': action.resource_view_create,
-            'resource_view_update': action.resource_view_update
+            'resource_view_update': action.resource_view_update,
         }
+
+    # IValidators
+    def get_validators(self):
+        return {
+            'iaea_owner_org_validator': validators.package_organization_validator,
+        }
+
     # IBlueprint
     def get_blueprint(self):
         blueprint = Blueprint(self.name, self.__module__)

--- a/ckanext/iaea/presets.json
+++ b/ckanext/iaea/presets.json
@@ -1,0 +1,18 @@
+{
+    "scheming_presets_version": 1,
+    "about": "Additional presets for IAEA schema",
+    "about_url": "http://github.com/keitaroinc/ckanext-iaea",
+    "presets": [{
+        "preset_name": "not_displayed",
+        "values": {
+          "validators": "ignore_missing",
+          "form_snippet": "snippets/form/hidden.html"
+        }
+    }, {
+        "preset_name": "iaea_dataset_organization",
+        "values": {
+            "validators": "owner_org_validator unicode iaea_owner_org_validator",
+            "form_snippet": "snippets/form/organization.html"
+        }
+    }]
+}

--- a/ckanext/iaea/templates/package/read_base.html
+++ b/ckanext/iaea/templates/package/read_base.html
@@ -71,6 +71,7 @@
     <div class="col-xs-4 right-content">
       <div class="pull-right" style="margin-top: 20px;">
         {% block title_and_actions_right_side %}
+        {% if pkg.organization %}
         {% set org = h.get_organization(pkg.organization.name) %}
         {% set url_org = h.url_for(pkg.organization.type + '_read', id=pkg.organization.name, ) %}
         <div class="table-valign" style="width: 100%;">
@@ -81,6 +82,7 @@
             </a>
           </div>
         </div>
+        {% endif %}
         {% endblock %}
       </div>
     </div>

--- a/ckanext/iaea/templates/snippets/form/_organization_select.html
+++ b/ckanext/iaea/templates/snippets/form/_organization_select.html
@@ -1,0 +1,34 @@
+{% import 'macros/form.html' as form %}
+
+{# this snippet is meant to be called from organization.html,
+not used as a form_snippet directly #}
+
+{% macro _organization() %}
+  {% set existing_org = data.owner_org or data.group_id %}
+  {% call form.input_block('field-organizations',
+    label=h.scheming_language_text(field.label),
+    error=errors[field.field_name],
+    is_required=org_required,
+    classes=['form-group', 'control-medium'],
+    extra_html=caller() if caller,
+    ) %}
+    <div {{
+      form.attributes(field.form_attrs) if 'form_attrs' in field else '' }}>
+    <select id="field-organizations" name="owner_org" {{ form.attributes(
+        field.get('form_select_attrs', {'data-module':'autocomplete'})) }}>
+      {% if not org_required or field.get('form_include_blank_choice', false) %}
+        <option value="">{% if not org_required
+          %}{{ _('No organization') }}{% endif %}</option>
+      {% endif %}
+      {% for organization in organizations_available %}
+        {% set selected_org = existing_org == organization.id %}
+        {{ organization_option_tag(organization, selected_org) }}
+      {% endfor %}
+    </select>
+    </div>
+  {% endcall %}
+{% endmacro %}
+
+{% call _organization() %}
+  {%- snippet 'scheming/form_snippets/help_text.html', field=field %}
+{% endcall %}

--- a/ckanext/iaea/templates/snippets/form/hidden.html
+++ b/ckanext/iaea/templates/snippets/form/hidden.html
@@ -1,0 +1,5 @@
+{# Empty snippet that does not render any html.
+It is used in the 'not_displayed' preset for values we do not want
+to display or edit.
+#}
+<input type="hidden" name="{{field.field_name}}" value="{{data[field.field_name]}}" />

--- a/ckanext/iaea/templates/snippets/form/organization.html
+++ b/ckanext/iaea/templates/snippets/form/organization.html
@@ -1,0 +1,36 @@
+{# This is specific to datasets' owner_org field and won't work #}
+{# if used with other fields #}
+
+
+{% macro organization_option_tag(organization, selected_org) %}
+  {% block organization_option scoped %}
+    <option value="{{ organization.id }}"{%
+      if selected_org %} selected="selected"{% endif
+      %}>{{ organization.display_name }}</option>
+  {% endblock %}
+{% endmacro %}
+
+  <div data-module="dataset-visibility">
+  {% snippet "scheming/form_snippets/_organization_select.html",
+    field=field,
+    data=data,
+    errors=errors,
+    organizations_available=h.iaea_get_available_organizations(data),
+    org_required=not h.check_config_permission('create_unowned_dataset')
+      or h.scheming_field_required(field),
+    organization_option_tag=organization_option_tag %}
+
+  {% block package_metadata_fields_visibility %}
+    <div class="control-group form-group control-medium">
+      <label for="field-private" class="control-label">{{ _('Visibility') }}</label>
+      <div class="controls">
+        <select id="field-private" name="private" class="form-control">
+          {% for option in [('True', _('Private')), ('False', _('Public'))] %}
+          <option value="{{ option[0] }}" {% if option[0] == data.private|trim %}selected="selected"{% endif %}>{{ option[1] }}</option>
+          {% endfor %}
+        </select>
+      </div>
+    </div>
+  {% endblock %}
+
+  </div>


### PR DESCRIPTION
Adds custom IAEA metadata schema for dataset create and update:
 - custom ckanext-scheming schema
 - adds custom presets for the organization to restrict it to only be IAEA or an empty one (for compatibility older datasets that belong to other organizations can keep that owner org)
 - Adds custom helpers and validators