### PR TITLE
openness snipett replacement

### DIFF
--- a/ckanext/iaea/templates/snippets/organization.html
+++ b/ckanext/iaea/templates/snippets/organization.html
@@ -1,6 +1,3 @@
 {% ckan_extends %}
 {% block info %}
-    {% block package_openness %}
-        {{ super() }} 
-    {% endblock %}
 {% endblock %}


### PR DESCRIPTION
Relocate openness snippet from organisazion.html becouse we have datasets without organisations.