### PR TITLE
Json resource css fix

### DIFF
--- a/ckanext/iaea/fanstatic/css/iaea-custom.css
+++ b/ckanext/iaea/fanstatic/css/iaea-custom.css
@@ -2,7 +2,7 @@
   width: 100%;
 }
 #json_schema_clear_button{
-  margin-right:25px;
+  margin-right: 25px;
 }
 /* This section is because the css for json resource is overwriten in ckanext-geoview with different iconset*/
 .format-label[data-format=json], 

--- a/ckanext/iaea/fanstatic/css/iaea-custom.css
+++ b/ckanext/iaea/fanstatic/css/iaea-custom.css
@@ -2,5 +2,13 @@
   width: 100%;
 }
 #json_schema_clear_button{
-  margin-right: 25px;
+  margin-right:25px;
+}
+/* This section is because the css for json resource is overwriten in ckanext-geoview with different iconset*/
+.format-label[data-format=json], 
+.format-label[data-format*=json] {
+  width: 32px;
+  height: 35px;
+  background-position: -288px -62px;
+  background-image:url("/base/images/sprite-resource-icons.png") !important;
 }


### PR DESCRIPTION
The css for [data-format=json] is overwritten in ckanext-geoview/ckanext/geoview/public/css/geo-resource-styles.css